### PR TITLE
remove cloning of ProximalBase from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
         - gfortran
 sudo: false
 script:
-  - julia -e 'Pkg.clone("https://github.com/mlakolar/ProximalBase.jl"); Pkg.clone(pwd()); Pkg.build("CoordinateDescent"); Pkg.test("CoordinateDescent"; coverage=true)'
+  - julia -e 'Pkg.clone(pwd()); Pkg.build("CoordinateDescent"); Pkg.test("CoordinateDescent"; coverage=true)'
 after_success:
     - echo $TRAVIS_JULIA_VERSION
     - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("CoordinateDescent")); using Coverage; Codecov.submit(process_folder())'


### PR DESCRIPTION
now that it's registered, better to let version resolution use a release
which will match what most users of the package will get